### PR TITLE
Error handling for async requests to storyblok

### DIFF
--- a/components/Drawer.vue
+++ b/components/Drawer.vue
@@ -5,7 +5,8 @@
     @input="$emit('toggleDrawer', $event)"
     app
     class="secondary darken-2"
-    dark>
+    dark
+  >
     <v-list>
       <v-list-tile to="/about">
         <v-list-tile-title class="subheading">{{ $t("menu.about") }}</v-list-tile-title>
@@ -22,6 +23,9 @@
       <v-list-tile to="/library">
         <v-list-tile-title class="subheading">{{ $t("menu.library") }}</v-list-tile-title>
       </v-list-tile>
+      <v-list-tile href="https://dev.to/vuevixens" target="_blank">
+        <v-list-tile-title class="subheading">Blog</v-list-tile-title>
+      </v-list-tile>
       <v-list-tile href="https://vuevixens.threadless.com/" target="_blank">
         <v-list-tile-title class="subheading">{{ $t("menu.shop") }}</v-list-tile-title>
       </v-list-tile>
@@ -30,12 +34,12 @@
 </template>
 
 <script>
-  import messages from '../assets/translations/header'
+import messages from "../assets/translations/header";
 
-  export default {
-    props: ['showDrawer'],
-    i18n: {
-      messages
-    },
+export default {
+  props: ["showDrawer"],
+  i18n: {
+    messages
   }
+};
 </script>

--- a/mixins/storyblok.js
+++ b/mixins/storyblok.js
@@ -27,9 +27,13 @@ export default {
     let version =
       context.query._storyblok || context.isDev ? 'draft' : 'published';
     const path = formatPath(context.route.path, context.app.i18n.locale);
+
     const response = await context.app.$storyapi.get(path, {
       version,
+    }).catch(err => {
+      return context.error({ statusCode: 404 });
     });
+
     return response.data;
   },
   mounted() {

--- a/pages/Team.vue
+++ b/pages/Team.vue
@@ -84,6 +84,10 @@
               <v-card-title justify-center>
                 <h3 class="d-block text-xs-center">{{member.name}}</h3>
                 <h4 class="d-block text-xs-center primary--text text--darken-2">{{member.title}} Chapter Leader</h4>
+                <a class="text-xs-center"
+                   v-if="member.twitter" :href="'http://www.twitter.com/' + member.twitter">
+                  <i class="fab fa-twitter"></i> @{{member.twitter}}
+                </a>
               </v-card-title>
             </v-card>
           </v-flex>


### PR DESCRIPTION
When visiting a dynamic storyblok based page with a wrong url, the server throws a 500 and dies. This will make it a redirect with 404 to the error page. EX: vuevixens.org/galleries/adsfadsf