### PR TITLE
fix eventMembers word overlap

### DIFF
--- a/components/EventMembers.vue
+++ b/components/EventMembers.vue
@@ -47,4 +47,8 @@ a,
 p {
   width: 100%;
 }
+
+.subheading, .v-card__title {
+  word-break: break-word;
+}
 </style>

--- a/pages/events/_event.vue
+++ b/pages/events/_event.vue
@@ -59,7 +59,7 @@
       <v-divider></v-divider>
       <h1 class="text-xs-center primary--text font-lato mt-3">Sponsors</h1>
       <v-container pa-4>
-        <v-layout row wrap justify-space-around>
+        <v-layout row wrap justify-space-around align-center>
           <v-flex xs12 sm3 v-for="sponsor in currentEvent.sponsors" :key="sponsor.name">
             <div class="vv-day-sponsor px-4 mb-3">
               <a :href="sponsor.website.url" target="_blank">


### PR DESCRIPTION
Fix the following issues: 

- In the event page, when the names or usernames of the event members are long, the text is overlapping the card in some viewports.

![image](https://user-images.githubusercontent.com/10585946/67979493-63fdb080-fbea-11e9-9de5-ba5389732983.png)

![image](https://user-images.githubusercontent.com/10585946/67979465-50524a00-fbea-11e9-9d59-b74c1b5c63e5.png)

- The sponsors list is not vertically aligned

![image](https://user-images.githubusercontent.com/10585946/67979604-9effe400-fbea-11e9-9374-3c35c05def61.png)
